### PR TITLE
allow json format via zenoh, rvised test, multiple config files, deactivated autostart of zenoh bridge at cli startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ adore_embedded/build/
 **.rej
 **.orig
 ros2_workspace/src/vendor/adore_extended
+ros2_workspace/src/adore_extended
 Function
 tools/adore_api/scenario_manager_state.json
 

--- a/adore.env
+++ b/adore.env
@@ -68,7 +68,7 @@ ZENOH_BRIDGE_CONFIG=${SOURCE_DIRECTORY}/ros2_workspace/src/adore_interfaces/zeno
 # - Set to "true" to launch the bridge node alongside the CLI container.
 # - Set to "false" or leave unset to disable.
 # - Default: false
-ZENOH_BRIDGE_ENABLE=true
+ZENOH_BRIDGE_ENABLE=false
 
 # ZENOH_BRIDGE_ROUTER: Zenoh router endpoint the bridge node connects to.
 # - Default: tcp/localhost:7447

--- a/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/README.md
+++ b/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/README.md
@@ -26,9 +26,28 @@ zenoh_to_ros2:
     msg_type: "std_msgs/msg/String"
 ```
 
-Each mapping accepts optional overrides: `format` (`cdr` | `json` | `cdr_json`), `domain_id`, `qos_depth`, `qos_reliability` (`reliable` | `best_effort`), `qos_durability` (`volatile` | `transient_local`).
+Each mapping accepts optional overrides: `format` (`cdr` | `json` | `cdr_json`), `domain_id`, `zenoh_key`, `qos_depth`, `qos_reliability` (`reliable` | `best_effort`), `qos_durability` (`volatile` | `transient_local`).
+
+`zenoh_key` replaces the derived key expression, which is `<domain_id>/<topic>/<dds_type>/<type_hash>`
+for publishing and `<domain_id>/<topic>/<dds_type>/*` for subscribing. Use it when the peer is not a
+ROS node. It makes `domain_id` irrelevant for that mapping and suppresses the liveliness token on
+`ros2_to_zenoh`.
 
 Top-level keys: `ros_domain_id`, `zenoh_bridge_id`, `rmw_target` (`humble` | `jazzy`).
+
+### Multiple config files
+
+`config_paths` takes a comma separated list of files and merges them in order.
+
+```bash
+ros2 launch zenoh_message_bridge bridge.launch.py \
+    config_paths:=/opt/site/vehicles.yaml,/opt/site/services.yaml
+```
+
+Mappings from all files are concatenated. Top-level keys are taken from the first file that sets
+them, so put `ros_domain_id`, `zenoh_bridge_id` and `rmw_target` in the first file. 
+
+`config_paths` takes precedence over `config_path` when both are given.
 
 ## Build
 
@@ -43,10 +62,36 @@ source install/setup.bash
 ros2 launch zenoh_message_bridge bridge.launch.py zenoh_router:=tcp/localhost:7447
 ```
 
+Launch arguments: `config_path`, `config_paths`, `zenoh_router`, `zenoh_config_path`.
+
 ## Test
 
 ```bash
-python3 zenoh_publish.py    # publish to Zenoh
-python3 zenoh_echo.py       # subscribe on Zenoh
-ros2 topic echo /zenoh_chatter
+zenohd --config zenoh_router_config.json5
+
+ros2 launch zenoh_message_bridge bridge.launch.py \
+    config_path:=$(ros2 pkg prefix --share zenoh_message_bridge)/test/bridge_config.test.yaml \
+    zenoh_config_path:=zenoh_bridge_config.json5
 ```
+
+Zenoh to ROS 2:
+
+```bash
+python3 zenoh_publish.py                                 # json
+ros2 topic echo /test/json_in
+
+python3 zenoh_publish.py --key test/cdr_in --format cdr  # cdr
+ros2 topic echo /test/cdr_in
+```
+
+ROS 2 to zenoh:
+
+```bash
+ros2 topic pub /test/json_out std_msgs/msg/String "{data: 'hi'}"
+python3 zenoh_echo.py                                    # json
+
+ros2 topic pub /test/cdr_out std_msgs/msg/String "{data: 'hi'}"
+python3 zenoh_echo.py --key test/cdr_out --format cdr    # cdr
+```
+
+Use `zenoh_echo.py --format raw` to print the bytes.

--- a/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/launch/bridge.launch.py
+++ b/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/launch/bridge.launch.py
@@ -1,24 +1,37 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from ament_index_python.packages import get_package_share_directory
 import os
 
-def generate_launch_description():
+def default_config_path():
     pkg_share = get_package_share_directory('zenoh_message_bridge')
-    bridge_config = os.path.join(pkg_share, 'config', 'bridge_config.yaml')
+    return os.path.join(pkg_share, 'config', 'bridge_config.yaml')
 
-    return LaunchDescription([
-        DeclareLaunchArgument('zenoh_router', default_value='tcp/localhost:7447'),
-        DeclareLaunchArgument('zenoh_config_path', default_value=''),
+def bridge_node(context, *args, **kwargs):
+    paths = LaunchConfiguration('config_paths').perform(context)
+    config_paths = [p.strip() for p in paths.split(',') if p.strip()]
+
+    return [
         Node(
             package='zenoh_message_bridge',
             executable='bridge_node',
             parameters=[{
-                'config_path': bridge_config,
+                'config_path': LaunchConfiguration('config_path'),
+                'config_paths': config_paths or [''],
                 'zenoh_config_path': LaunchConfiguration('zenoh_config_path'),
                 'zenoh_router': LaunchConfiguration('zenoh_router'),
             }]
         )
+    ]
+
+def generate_launch_description():
+    return LaunchDescription([
+        DeclareLaunchArgument('config_path', default_value=default_config_path()),
+        DeclareLaunchArgument('config_paths', default_value='',
+                              description='Comma separated config files, merged in order. Takes precedence over config_path.'),
+        DeclareLaunchArgument('zenoh_router', default_value='tcp/localhost:7447'),
+        DeclareLaunchArgument('zenoh_config_path', default_value=''),
+        OpaqueFunction(function=bridge_node),
     ])

--- a/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/setup.py
+++ b/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/setup.py
@@ -13,6 +13,7 @@ setup(
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name + '/config', ['config/bridge_config.yaml']),
         ('share/' + package_name + '/launch', ['launch/bridge.launch.py']),
+        ('share/' + package_name + '/test', ['test/bridge_config.test.yaml']),
     ],
     install_requires=['setuptools', 'yq', 'eclipse-zenoh'],
     zip_safe=True,

--- a/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/test/bridge_config.test.yaml
+++ b/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/test/bridge_config.test.yaml
@@ -1,0 +1,32 @@
+# Config for the test procedure in README.md, both wire formats in both directions.
+# zenoh_key is set everywhere so the keys can be typed by hand.
+
+ros_domain_id: 0
+zenoh_bridge_id: 0
+rmw_target: jazzy
+
+zenoh_to_ros2:
+  - ros_topic: "/test/json_in"
+    msg_type: "std_msgs/msg/String"
+    format: json
+    zenoh_key: "test/json_in"
+    qos_depth: 10
+
+  - ros_topic: "/test/cdr_in"
+    msg_type: "std_msgs/msg/String"
+    format: cdr
+    zenoh_key: "test/cdr_in"
+    qos_depth: 10
+
+ros2_to_zenoh:
+  - ros_topic: "/test/json_out"
+    msg_type: "std_msgs/msg/String"
+    format: json
+    zenoh_key: "test/json_out"
+    qos_depth: 10
+
+  - ros_topic: "/test/cdr_out"
+    msg_type: "std_msgs/msg/String"
+    format: cdr
+    zenoh_key: "test/cdr_out"
+    qos_depth: 10

--- a/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/zenoh_echo.py
+++ b/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/zenoh_echo.py
@@ -1,19 +1,48 @@
-import zenoh
+"""Subscribe to a bridge key over zenoh and print what arrives."""
+import argparse
+import json
 import struct
+import zenoh
 
-def decode_string(payload: bytes) -> str:
-    # CDR string: 4-byte header + 4-byte length + string bytes (null terminated)
+DEFAULT_ENDPOINT = 'tcp/127.0.0.1:7446'
+
+
+def decode(payload: bytes, fmt: str) -> str:
+    if fmt == 'raw':
+        return repr(payload)
+    if fmt == 'json':
+        return json.dumps(json.loads(payload.decode('utf-8')))
+    # CDR std_msgs/msg/String: 4 byte encapsulation header, 4 byte length
+    # including the terminator, then the string.
     length = struct.unpack_from('<I', payload, 4)[0]
+    if len(payload) != 8 + length:
+        raise ValueError(f'not CDR: length field {length} does not match {len(payload)} bytes')
     return payload[8:8 + length - 1].decode('utf-8')
 
-conf = zenoh.Config.from_json5('''
-{
-  mode: "peer",
-  connect: { endpoints: ["tcp/127.0.0.1:7447"] }
-}
-''')
 
-with zenoh.open(conf) as session:
-    with session.declare_subscriber("zenoh/chatter") as sub:
-        for sample in sub:
-            print(f"[{sample.key_expr}] {decode_string(sample.payload.to_bytes())}")
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-k', '--key', default='test/json_out')
+    parser.add_argument('-e', '--endpoint', default=DEFAULT_ENDPOINT)
+    parser.add_argument('-f', '--format', choices=('json', 'cdr', 'raw'), default='json',
+                        help="must match the mapping's format in the bridge config")
+    args = parser.parse_args()
+
+    conf = zenoh.Config.from_json5(json.dumps({
+        'mode': 'client',
+        'connect': {'endpoints': [args.endpoint]},
+    }))
+
+    print(f'Subscribed to {args.key} via {args.endpoint}, waiting for samples')
+    with zenoh.open(conf) as session:
+        with session.declare_subscriber(args.key) as sub:
+            for sample in sub:
+                data = sample.payload.to_bytes()
+                try:
+                    print(f'[{sample.key_expr}] {decode(data, args.format)}')
+                except Exception as e:
+                    print(f'[{sample.key_expr}] not decodable as {args.format}: {e}: {data!r}')
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/zenoh_message_bridge/bridge_node.py
+++ b/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/zenoh_message_bridge/bridge_node.py
@@ -3,6 +3,7 @@ import queue
 import struct
 import threading
 import time
+import traceback
 import uuid
 import yaml
 import zenoh
@@ -122,25 +123,46 @@ def _qos_from_mapping(mapping: dict, default_reliability: str = 'reliable') -> Q
         history=HistoryPolicy.KEEP_LAST,
     )
 
+_MAPPING_KEYS = ('ros2_to_zenoh', 'zenoh_to_ros2')
+
+def _merge_configs(configs: list) -> dict:
+    """Merge in file order: mappings are concatenated, other keys taken from the first file setting them."""
+    merged = {}
+    for config in configs:
+        for key, value in config.items():
+            if key in _MAPPING_KEYS:
+                merged.setdefault(key, []).extend(value or [])
+            elif key not in merged:
+                merged[key] = value
+    return merged
+
+def _duplicate_topics(config: dict) -> list:
+    """Topics mapped more than once in the same direction."""
+    duplicates = []
+    for key in _MAPPING_KEYS:
+        seen = set()
+        for mapping in config.get(key, []):
+            topic = mapping.get('ros_topic')
+            if topic in seen:
+                duplicates.append(topic)
+            seen.add(topic)
+    return duplicates
+
+# Bounded, so a burst on the zenoh side cannot starve the ros2_to_zenoh subscriptions
+_MAX_PUBLISHES_PER_TICK = 100
+
 
 class ROS2ZenohBridge(Node):
     def __init__(self):
         super().__init__('zenoh_bridge_node')
         self.declare_parameter('config_path', '')
+        self.declare_parameter('config_paths', [''])
         self.declare_parameter('zenoh_config_path', '')
         self.declare_parameter('zenoh_router', 'tcp/localhost:7447')
 
-        config_path = self.get_parameter('config_path').get_parameter_value().string_value
-        if not config_path or not os.path.exists(config_path):
-            self.get_logger().error(f"Config file not found: {config_path}")
-            return
-
-        try:
-            with open(config_path, 'r') as f:
-                self.config = yaml.safe_load(f)
-        except Exception as e:
-            self.get_logger().error(f"Failed to load config: {e}")
-            return
+        self.config = self._load_config()
+        if self.config is None:
+            raise RuntimeError('no usable bridge configuration')
 
         self._ros_domain_id   = int(self.config.get('ros_domain_id', os.environ.get('ROS_DOMAIN', '0')))
         self._zenoh_bridge_id = int(self.config.get('zenoh_bridge_id', 0))
@@ -159,6 +181,39 @@ class ROS2ZenohBridge(Node):
         self._setup_ros2_to_zenoh()
         self._setup_zenoh_to_ros2()
         self.create_timer(0.01, self._drain_z2r_queue)
+
+    def _config_paths(self) -> list:
+        """Paths from 'config_paths' when set, otherwise the single 'config_path'."""
+        paths = [p for p in self.get_parameter('config_paths').get_parameter_value().string_array_value if p]
+        if paths:
+            return paths
+        config_path = self.get_parameter('config_path').get_parameter_value().string_value
+        return [config_path] if config_path else []
+
+    def _load_config(self):
+        """Load every configured file and merge them. Returns None if any of them is unusable."""
+        paths = self._config_paths()
+        if not paths:
+            self.get_logger().error("No config file given, set config_path or config_paths")
+            return None
+
+        configs = []
+        for path in paths:
+            if not os.path.exists(path):
+                self.get_logger().error(f"Config file not found: {path}")
+                return None
+            try:
+                with open(path, 'r') as f:
+                    configs.append(yaml.safe_load(f) or {})
+            except Exception as e:
+                self.get_logger().error(f"Failed to load config {path}: {e}")
+                return None
+            self.get_logger().info(f'Config loaded: {path}')
+
+        config = _merge_configs(configs)
+        for topic in _duplicate_topics(config):
+            self.get_logger().warn(f'{topic} is mapped more than once and will be bridged repeatedly')
+        return config
 
     def _setup_zenoh(self):
         zenoh_config_path = self.get_parameter('zenoh_config_path').get_parameter_value().string_value
@@ -189,13 +244,16 @@ class ROS2ZenohBridge(Node):
             wtype     = _wire_type(ros_type, fmt)
             serialize = _serializer(ros_type, fmt)
 
-            zenoh_key = _topic_keyexpr(domain_id, ros_topic, wtype, self._rmw_target)
+            custom_key = mapping.get('zenoh_key')
+            zenoh_key = custom_key or _topic_keyexpr(domain_id, ros_topic, wtype, self._rmw_target)
             pub = self.zenoh_session.declare_publisher(zenoh_key)
             self.zenoh_pubs[ros_topic] = pub
 
-            lv_key = _liveliness_keyexpr(domain_id, self._session_id, pub_id, node_name, ros_topic, wtype, qos, self._rmw_target)
-            token = self.zenoh_session.liveliness().declare_token(lv_key)
-            self.zenoh_lv_tokens.append(token)
+            # A custom key is not an rmw_zenoh_cpp topic, so do not advertise one.
+            if not custom_key:
+                lv_key = _liveliness_keyexpr(domain_id, self._session_id, pub_id, node_name, ros_topic, wtype, qos, self._rmw_target)
+                token = self.zenoh_session.liveliness().declare_token(lv_key)
+                self.zenoh_lv_tokens.append(token)
 
             gid = _make_gid()
             seq = [0]
@@ -214,12 +272,11 @@ class ROS2ZenohBridge(Node):
             domain_id = int(mapping.get('domain_id', self._zenoh_bridge_id))
             fmt       = mapping.get('format', 'cdr')
             wtype     = _wire_type(ros_type, fmt)
-            pub_type  = load_msg_type(wtype)
             m_type    = load_msg_type(ros_type)
             qos       = _qos_from_mapping(mapping, default_reliability='best_effort')
-            z_key     = _topic_sub_keyexpr(domain_id, ros_topic, wtype)
+            z_key     = mapping.get('zenoh_key') or _topic_sub_keyexpr(domain_id, ros_topic, wtype)
             deserialize = _deserializer(m_type, fmt)
-            pub = self.create_publisher(pub_type, ros_topic, qos)
+            pub = self.create_publisher(m_type, ros_topic, qos)
             self.ros_pubs[ros_topic] = pub
             self.get_logger().info(f'Z2R: {z_key} -> {ros_topic} [{fmt}]')
             def z_cb(sample, p=pub, t=ros_topic, deser=deserialize):
@@ -232,9 +289,15 @@ class ROS2ZenohBridge(Node):
             self.zenoh_subs.append(self.zenoh_session.declare_subscriber(z_key, z_cb))
 
     def _drain_z2r_queue(self):
-        while not self._z2r_queue.empty():
-            pub, msg = self._z2r_queue.get_nowait()
-            pub.publish(msg)
+        for _ in range(_MAX_PUBLISHES_PER_TICK):
+            try:
+                pub, msg = self._z2r_queue.get_nowait()
+            except queue.Empty:
+                return
+            try:
+                pub.publish(msg)
+            except Exception as e:
+                self.get_logger().error(f'Publish failed on {pub.topic_name}: {e}')
 
     def shutdown(self):
         self._shutdown_event.set()
@@ -248,7 +311,14 @@ class ROS2ZenohBridge(Node):
 
 def main(args=None):
     rclpy.init(args=args)
-    node = ROS2ZenohBridge()
+
+    try:
+        node = ROS2ZenohBridge()
+    except Exception:
+        traceback.print_exc()
+        rclpy.shutdown()
+        return 1
+
     executor = MultiThreadedExecutor()
     executor.add_node(node)
     try:
@@ -260,3 +330,4 @@ def main(args=None):
         executor.shutdown()
         node.destroy_node()
         rclpy.shutdown()
+    return 0

--- a/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/zenoh_publish.py
+++ b/ros2_workspace/src/adore_interfaces/zenoh_message_bridge/zenoh_publish.py
@@ -1,18 +1,50 @@
-import zenoh
+"""Publish a std_msgs/msg/String to the bridge over zenoh."""
+import argparse
 import json
+import struct
 import time
+import zenoh
 
-conf = zenoh.Config.from_json5('''
-{
-  mode: "client",
-  connect: { endpoints: ["tcp/127.0.0.1:7447"] }
-}
-''')
+DEFAULT_ENDPOINT = 'tcp/127.0.0.1:7446'
 
-with zenoh.open(conf) as session:
-    pub = session.declare_publisher("zenoh/chatter")
-    while True:
-        payload = json.dumps({"data": "Hello, Zenoh!"}).encode('utf-8')
-        pub.put(payload)
-        print("Published: Hello, Zenoh!")
-        time.sleep(1)
+
+def encode(text: str, fmt: str) -> bytes:
+    if fmt == 'json':
+        return json.dumps({'data': text}).encode('utf-8')
+    # CDR std_msgs/msg/String: encapsulation header, length including the
+    # terminator, then the null terminated string.
+    body = text.encode('utf-8')
+    return b'\x00\x01\x00\x00' + struct.pack('<I', len(body) + 1) + body + b'\x00'
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-k', '--key', default='test/json_in')
+    parser.add_argument('-e', '--endpoint', default=DEFAULT_ENDPOINT)
+    parser.add_argument('-f', '--format', choices=('json', 'cdr'), default='json',
+                        help="must match the mapping's format in the bridge config")
+    parser.add_argument('-m', '--message', default='Hello, Zenoh!')
+    parser.add_argument('-n', '--count', type=int, default=0,
+                        help='number of samples, 0 publishes until interrupted')
+    parser.add_argument('-i', '--interval', type=float, default=1.0)
+    args = parser.parse_args()
+
+    conf = zenoh.Config.from_json5(json.dumps({
+        'mode': 'client',
+        'connect': {'endpoints': [args.endpoint]},
+    }))
+
+    payload = encode(args.message, args.format)
+    with zenoh.open(conf) as session:
+        pub = session.declare_publisher(args.key)
+        sent = 0
+        while args.count == 0 or sent < args.count:
+            pub.put(payload)
+            sent += 1
+            print(f'[{args.key}] {args.format}: {args.message}')
+            if args.count == 0 or sent < args.count:
+                time.sleep(args.interval)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description

This PR:
- deactivates the autostart of the zenoh bridge with the adore cli -> zenoh bridge needs to be started manually or together with the secenario launch file
- adds 'config_paths' launch parameter to zenoh bridge. This feature allows to have multiple config files in different directories to configure the zenoh bridge
- adds changes for json (non-ROS) clients
- should not change behaviour for ROS clients

Fixes #(issue-number)

## Type of Change

Please delete options that are not relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) -> Deactivated autostart of zenoh bridge -> Manual start required with launch file
- [x] Documentation update (adds or updates documentation)
- [ ] Refactor (non-breaking change for code readability/structure)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have signed and submitted the Eclipse Foundation Contributors Agreement: https://www.eclipse.org/legal/eca/.
- [x] My last commit was made with the `--signoff` flag as required by the Eclipse Foundation.
- [x] I have commented my code, particularly in hard-to-understand areas and provided a README.md when necessary.
- [x] I have added tests that prove my fix is effective or that my feature works.


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

The test is described in ros2_workspace/src/adore_interfaces/zenoh_message_bridge/README.md

